### PR TITLE
Setup GitHub Actions Workflow for Render Deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,11 @@
+name: Deploy to Render
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Render Deploy
+        run: curl -X POST ${{ secrets.RENDER_DEPLOY_HOOK_URL }}


### PR DESCRIPTION
This change adds a GitHub Actions workflow to automate the deployment of the project to Render. The workflow is triggered on pushes to the `main` branch and uses a deploy hook to initiate the deployment.

Fixes #20

---
*PR created automatically by Jules for task [8445114633400607200](https://jules.google.com/task/8445114633400607200) started by @rajeshceg3*